### PR TITLE
Define "maintainers" to prevent privilege escalation

### DIFF
--- a/license.md
+++ b/license.md
@@ -4,7 +4,7 @@ Copyright $AUTHOR <$EMAIL> $YEAR.
 
 Software provided as-is; no warranty.
 
-This is an agreement between you (either as a personal individual or as a corporation, organization, or other entity on behalf of which you are permitted to accept such agreements) and the Maintainers (the individuals and/or organizations listed above after "Copyright"). Unless you have a separate agreement with the Maintainers granting additional use, you may only use, modify, share, or otherwise take advantage of the software in the ways described below.
+This is an agreement between you (either as a personal individual or as a corporation, organization, or other entity on behalf of which you are permitted to accept such agreements) and the Maintainers (which refers only to the individuals and/or organizations named above after "Copyright"). Unless you have a separate agreement with the Maintainers granting additional use, you may only use, modify, share, or otherwise take advantage of the software in the ways described below.
 
 Available without charge for the following purposes:
 
@@ -26,7 +26,7 @@ With the following conditions:
 - Free use under this license may continue indefinitely for released projects that remain based on the same version of the software, including for commercial projects where the related entities turnover or income begins to exceed the small entity threshold. A commercial license should be sought before updating the software.
 - Free use within other projects does not confer the right to issue a commercial license.
 
-For any other use, a commercial license is required, and should be separately negotiated with the Maintainers listed above via email.
+For any other use, a commercial license is required, and should be separately negotiated with the Maintainers via email.
 
 The following expectations generally apply to commercial licenses for HOOP software:
 

--- a/license.md
+++ b/license.md
@@ -4,6 +4,8 @@ Copyright $AUTHOR <$EMAIL> $YEAR.
 
 Software provided as-is; no warranty.
 
+This is an agreement between you (either as a personal individual or as a corporation, organization, or other entity on behalf of which you are permitted to accept such agreements) and the Maintainers (the individuals and/or organizations listed above after "Copyright"). Unless you have a separate agreement with the Maintainers granting additional use, you may only use, modify, share, or otherwise take advantage of the software in the ways described below.
+
 Available without charge for the following purposes:
 
 - Non-commercial use; where there is either no further distribution, or there is public distribution with no financial benefit.
@@ -24,7 +26,7 @@ With the following conditions:
 - Free use under this license may continue indefinitely for released projects that remain based on the same version of the software, including for commercial projects where the related entities turnover or income begins to exceed the small entity threshold. A commercial license should be sought before updating the software.
 - Free use within other projects does not confer the right to issue a commercial license.
 
-For any other use, a commercial license is required, and should be separately negotiated with the maintainers via email.
+For any other use, a commercial license is required, and should be separately negotiated with the Maintainers listed above via email.
 
 The following expectations generally apply to commercial licenses for HOOP software:
 
@@ -36,6 +38,6 @@ The following expectations generally apply to commercial licenses for HOOP softw
 - Commercial licenses will be publicly disclosed - disclosure can be deferred until after project release if required for per-project licenses, not for organisational licenses.
 - Fees may be deferred to the time of publicly shipping a small project.
 - Licensing fees will be utilised to fund the continued development of the software and other free software.
-- A commercial license may be granted freely at the maintainer's discretion.
+- A commercial license may be granted freely at the sole discretion of the Maintainers.
 
 When in doubt about your specific case, ask.


### PR DESCRIPTION
This PR tries to address (or at least illustrate) a potential ambiguity with the term "the maintainer(s)", specifically concerning this line:

> A commercial license may be granted freely at the maintainer's discretion.

My concern here is that "the maintainer" isn't defined and isn't clearly differentiated from an ordinary contributor, which introduces some ambiguity that seems exploitable. e.g. I get you to accept my PR, then claim that makes me a maintainer and gives me a right to grant commercial licenses, including to myself or my employer.

I think my wording here is a bit too dense and faux-legalese, but I figure it's a starting point and maybe more helpful than just dropping another open-ended issue into the queue. :slightly_smiling_face: 